### PR TITLE
3 custom logging out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+[1.3.0] 2018-01-15
+### Added
+- `SDLog` now uses a class `log_message` method to log -- this now
+supports a custom logging interface by inheriting from `SDLog` or
+replacing `log_message` in an application.
+```python
+class MyTestLogger(SDLog):
+    @classmethod
+    def log_message(cls, message: str, **kwargs):
+        print('SPECIAL LOGGER', message)
+```
+This class will print 'SPECIAL LOGGER' before all messages, but otherwise
+act the same as the normal `SDLog`. As another example, the `log_message`
+method could connect to and log to a database for non-console-based
+logging.

--- a/sd_utils/__tests__/test_sd_load.py
+++ b/sd_utils/__tests__/test_sd_load.py
@@ -9,8 +9,6 @@ Notes :
 December 14, 2017
 """
 
-import unittest
-
 from .base_test import BaseTestCase
 
 import sd_utils.sd_load as sdl

--- a/sd_utils/__tests__/test_sd_log.py
+++ b/sd_utils/__tests__/test_sd_log.py
@@ -1,0 +1,16 @@
+"""
+StratoDem Analytics : test_sd_log
+Principal Author(s) : Michael Clawar
+Secondary Author(s) :
+Description :
+
+Notes :
+
+January 13, 2018
+"""
+
+import time
+
+from .base_test import BaseTestCase
+
+from sd_utils.sd_log import SDLog

--- a/sd_utils/sd_log.py
+++ b/sd_utils/sd_log.py
@@ -181,7 +181,7 @@ class SDLog:
         # log_func as a partial function with max_expected_time already filled in, to be used as
         # the decorator again
         if func is None:
-            return functools.partial(log_func, max_expected_time=max_expected_time)
+            return functools.partial(cls.log_func, max_expected_time=max_expected_time)
 
         assert callable(func)
 
@@ -228,6 +228,22 @@ def log(*args) -> None:
 
 def log_func(func: Optional[Callable]=None,
              max_expected_time: Optional[Union[int, float]]=None) -> Callable[[Any], Any]:
+    """
+    Decorator which optionally takes max_expected_time, a number of seconds that a function may take
+    to execute before a SLOW FUNCTION message is logged
+
+    Parameters
+    ----------
+    func: callable
+        Function to decorate
+    max_expected_time: int or float
+        Number of seconds a function may take to execute before a SLOW FUNCTION message is logged
+
+    Returns
+    -------
+    callable
+        Wrapped function
+    """
     # If max_expected_time was passed in, then func will be none and we have to return
     # log_func as a partial function with max_expected_time already filled in, to be used as
     # the decorator again
@@ -282,8 +298,14 @@ if __name__ == '__main__':
     with MyTestLogger('Testing message') as sdl:
         sdl.log('test')
 
-    @MyTestLogger.log_func
+    @MyTestLogger.log_func(max_expected_time=1.5)
     def test_func4():
         MyTestLogger.quick_log('I am in 4')
 
+    @MyTestLogger.log_func(max_expected_time=1.5)
+    def test_func5():
+        time.sleep(2)
+        MyTestLogger.quick_log('I am in 5')
+
     test_func4()
+    test_func5()

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools import setup
 
 setup(
     name='SDUtils',
-    version='1.2.1',
+    version='1.3.0',
     packages=['sd_utils'],
     license='(c) 2017 StratoDem Analytics. All rights reserved.',
     description='StratoDem utilities',


### PR DESCRIPTION
`SDLog` now uses a class `log_message` method to log -- this now
supports a custom logging interface by inheriting from `SDLog` or
replacing `log_message` in an application.
```python
class MyTestLogger(SDLog):
    @classmethod
    def log_message(cls, message: str, **kwargs):
        print('SPECIAL LOGGER', message)
```
This class will print 'SPECIAL LOGGER' before all messages, but otherwise
act the same as the normal `SDLog`. As another example, the `log_message`
method could connect to and log to a database for non-console-based
logging.

Closes #3. 
