### PR TITLE
Update version to 2.6.4 - lock pandas version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools import setup
 
 setup(
     name='SDUtils',
-    version='2.6.3',
+    version='2.6.4',
     packages=['sd_utils'],
     license='(c) 2017- StratoDem Analytics. All rights reserved.',
     description='StratoDem utilities',


### PR DESCRIPTION
Fix pandas version to prevent Int64Index issues after deprecation and removal in 2.*