### PR TITLE
AB#422271 Configure SHIELD CI — arch:amd64, Python 3.9

### DIFF
--- a/.sdlcforge.json
+++ b/.sdlcforge.json
@@ -1,0 +1,52 @@
+{
+  "_comment": "SDLC Forge configuration file for SDUtils",
+  "schema_version": "1.0",
+  "projects": [
+    {
+      "type": "python",
+      "name": "SDUtils",
+      "path": "",
+      "runtime": {
+        "name": "python",
+        "version": "3.12"
+      },
+      "build_tool": {
+        "name": "venv",
+        "version": "3.12"
+      },
+      "dependency": {
+        "command": "python3.12 -m venv .venv && . .venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt"
+      },
+      "build": {
+        "command": ". .venv/bin/activate && python -m build"
+      },
+      "tests": [
+        {
+          "type": "unit",
+          "command": ". .venv/bin/activate && pip install pytest pytest-cov && pytest sd_utils/__tests__/ --cov=sd_utils --cov-report=xml:coverage-reports/coverage.xml --junitxml=test-reports/junit.xml -v"
+        }
+      ],
+      "artefacts": {
+        "source_code": [
+          "sd_utils/"
+        ],
+        "test_code": [
+          "sd_utils/__tests__/"
+        ],
+        "deliverable": [
+          "dist/*.whl",
+          "dist/*.tar.gz"
+        ],
+        "dependency_manifests": [
+          "requirements.txt"
+        ],
+        "tests_reports": [
+          "test-reports/junit.xml"
+        ],
+        "coverage_reports": [
+          "coverage-reports/coverage.xml"
+        ]
+      }
+    }
+  ]
+}

--- a/.sdlcforge.json
+++ b/.sdlcforge.json
@@ -1,6 +1,7 @@
 {
   "_comment": "SDLC Forge configuration file for SDUtils",
   "schema_version": "1.0",
+  "arch": "amd64",
   "projects": [
     {
       "type": "python",
@@ -8,14 +9,14 @@
       "path": "",
       "runtime": {
         "name": "python",
-        "version": "3.13"
+        "version": "3.9"
       },
       "build_tool": {
         "name": "venv",
-        "version": "3.13"
+        "version": "3.9"
       },
       "dependency": {
-        "command": "python3.13 -m venv .venv && . .venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt"
+        "command": "python3.9 -m venv .venv && . .venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt"
       },
       "build": {
         "command": ". .venv/bin/activate && python -m build"

--- a/.sdlcforge.json
+++ b/.sdlcforge.json
@@ -16,10 +16,10 @@
         "version": "3.9"
       },
       "dependency": {
-        "command": "python3.9 -m venv .venv && . .venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt"
+        "command": "python3.9 -m venv .venv && . .venv/bin/activate && pip install --upgrade pip && pip install 'numpy>=1.19,<2.0' && pip install -r requirements.txt"
       },
       "build": {
-        "command": ". .venv/bin/activate && python -m build"
+        "command": ". .venv/bin/activate && pip install build && python -m build"
       },
       "tests": [
         {

--- a/.sdlcforge.json
+++ b/.sdlcforge.json
@@ -8,14 +8,14 @@
       "path": "",
       "runtime": {
         "name": "python",
-        "version": "3.12"
+        "version": "3.13"
       },
       "build_tool": {
         "name": "venv",
-        "version": "3.12"
+        "version": "3.13"
       },
       "dependency": {
-        "command": "python3.12 -m venv .venv && . .venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt"
+        "command": "python3.13 -m venv .venv && . .venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt"
       },
       "build": {
         "command": ". .venv/bin/activate && python -m build"


### PR DESCRIPTION
SHIELD CI configuration (`.sdlcforge.json`).

**Key fixes:**
- arch:amd64 + Python 3.9 (numpy/pandas AMD64 wheels)
- numpy<2.0 pinned (ABI compat with pandas 1.3.4)
- pip install build before python -m build

**CI status:** DEPS ✅ BUILD ✅ UNIT ❌ blocked-dev (pyarrow>=2.0.0 incompatible with fastparquet/dask 2022.1.1 — dev must pin pyarrow<5.0)